### PR TITLE
Create a script to start scalar DL

### DIFF
--- a/apply_schema.sh
+++ b/apply_schema.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose exec cassandra cqlsh -f /create_schema.cql


### PR DESCRIPTION
This script will start the docker containers and also apply the schema. It's useful if you are always forgetting to apply the schema or if you often forget the command to apply the schema.