### PR TITLE
Add Envoy as front proxy to support gRPC-web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     #   - "9042:9042" # native protocol clients
     #   - "9160:9160" # thrift clients
 
-  scalar-server:
+  scalar-ledger:
     image: scalarlabs/scalar-ledger:1.1.0
     depends_on:
       - cassandra
@@ -21,7 +21,7 @@ services:
     networks:
       default:
         aliases:
-          - scalar-server
+          - scalar-ledger
 
   envoy:
     image: envoyproxy/envoy:v1.10.0
@@ -30,7 +30,7 @@ services:
     volumes:
       - ./envoy.yaml:/etc/envoy/envoy.yaml
     depends_on:
-      - scalar-server
+      - scalar-ledger
     command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l trace
 
   cfssl-init:

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -16,7 +16,7 @@ static_resources:
               domains: ["*"]
               routes:
               - match: { prefix: "/" }
-                route: { cluster: scalar-server }
+                route: { cluster: scalar-ledger }
               cors:
                 allow_origin:
                 - "*"
@@ -30,9 +30,9 @@ static_resources:
           - name: envoy.cors
           - name: envoy.router
   clusters:
-  - name: scalar-server
+  - name: scalar-ledger
     connect_timeout: 0.25s
     type: strict_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: scalar-server, port_value: 50051 }}]
+    hosts: [{ socket_address: { address: scalar-ledger, port_value: 50051 }}]


### PR DESCRIPTION
This PR adds a new compose service `envoy`.
Envoy acts as a proxy and it helps  transfer gRPC-web requests to gRPC requests.

**BEFORE**
```
gRPC requests -> scalar-server
```

**NOW**
```
gRPC/gRPC-web requests -> envoy -> scalar-server
```