### PR TITLE
Upgrade scalar-ledger to 2.0.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - SCALAR_DL_LEDGER_PROOF_PRIVATE_KEY_PATH=/scalar/bar-key.pem
     networks:
       - scalar-ledger
+    # Overriding the CMD instruction in the scalar-ledger Dockerfile to add the -wait option.
     command: |
       dockerize -template ledger.properties.tmpl:ledger.properties
       -template log4j.properties.tmpl:log4j.properties


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7450

It needs to override the command in docker-compose.yml to add the `-wait` option to the `dockerize` command since the option has been removed in this version.

Note: When we replace `scalardl-schema-loader-cassandra` with `scalardl-schema-loader` in a while, we will need to override the command of the image as well in the same way.