### PR TITLE
Fix to use scalardl-schema-loader image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,15 +18,16 @@ services:
       - scalar-ledger
 
   scalardl-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader-cassandra:1.0.0
-    environment:
-      - CASSANDRA_HOST=cassandra
-      - CASSANDRA_PORT=9042
-      - CASSANDRA_USERNAME=
-      - CASSANDRA_PASSWORD=
-      - CASSANDRA_REPLICATION_FACTOR=1
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:1.3.0
+    command:
+      - "--cassandra"
+      - "-h"
+      - "cassandra"
+      - "-R"
+      - "1"
     networks:
       - scalar-ledger
+    restart: on-failure
 
   scalar-ledger:
     image: ghcr.io/scalar-labs/scalar-ledger:2.1.0


### PR DESCRIPTION
# Description

Workaround for #19 

```
$ docker-compose ps
                      Name                                     Command               State                                            Ports
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
scalar-samples-cassandra-1                          docker-entrypoint.sh cassa ...   Up       7000/tcp, 7001/tcp, 7199/tcp, 9042/tcp, 9160/tcp
scalar-samples-cfssl-init-1                         docker-entrypoint.sh /bin/true   Exit 0
scalar-samples-cfssl-ocspserve-1                    docker-entrypoint.sh ocspserve   Up       8888/tcp, 0.0.0.0:8889->8889/tcp
scalar-samples-cfssl-serve-1                        docker-entrypoint.sh serve       Up       0.0.0.0:8888->8888/tcp, 8889/tcp
scalar-samples-envoy-1                              /docker-entrypoint.sh /usr ...   Up       10000/tcp, 0.0.0.0:50051->50051/tcp, 0.0.0.0:50052->50052/tcp, 0.0.0.0:9901->9901/tcp
scalar-samples-scalar-ledger-1                      dockerize -template ledger ...   Up       50051/tcp
scalar-samples_scalardl-schema-loader-cassandra_1   java -jar scalar-schema-st ...   Exit 0
```