### PR TITLE
Fix Scalar DL version

### DIFF
--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -15,7 +15,7 @@ services:
     restart: on-failure
 
   scalar-ledger-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.0.0
+    image: ghcr.io/scalar-labs/scalar-client:3.0.1
     container_name: "scalardl-samples-scalar-ledger-as-client-1"
     volumes:
       - ./fixture/ledger.pem:/scalar/ledger.pem
@@ -39,7 +39,7 @@ services:
     restart: on-failure:5
 
   scalar-audior-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.0.0
+    image: ghcr.io/scalar-labs/scalar-client:3.0.1
     container_name: "scalardl-samples-scalar-auditor-as-client-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem
@@ -67,7 +67,7 @@ services:
       - SCALAR_DL_LEDGER_AUDITOR_ENABLED=true
 
   scalar-auditor:
-    image: ghcr.io/scalar-labs/scalar-auditor:3.0.0
+    image: ghcr.io/scalar-labs/scalar-auditor:3.0.1
     container_name: "scalardl-samples-scalar-auditor-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     restart: on-failure
 
   scalar-ledger:
-    image: ghcr.io/scalar-labs/scalar-ledger:3.0.0
+    image: ghcr.io/scalar-labs/scalar-ledger:3.0.1
     container_name: "scalardl-samples-scalar-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem


### PR DESCRIPTION
Maybe we should use 3.0.1 for Scalar DL containers.