### PR TITLE
Upgrade scalardl-schema-loader to 3.2.0

### DIFF
--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   scalardl-auditor-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.1.0
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.2.0
     environment:
       - SCHEMA_TYPE=auditor
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - scalar-network
 
   scalardl-ledger-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.1.0
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.2.0
     command:
       - "--cassandra"
       - "-h"


### PR DESCRIPTION
This PR upgrades scalardl-schema-loader to version 3.2.0.