### PR TITLE
Upgrade Scalar DL to 3.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.2.0'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.3.0'
 }
 
 sourceCompatibility = 1.8

--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -1,21 +1,23 @@
 version: "3.5"
 services:
   scalardl-auditor-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.2.0
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.3.0
     environment:
       - SCHEMA_TYPE=auditor
+    volumes:
+      - ./scalardb.properties:/scalardb.properties
     command:
-      - "--cassandra"
-      - "-h"
-      - "cassandra"
-      - "-R"
+      - "-c"
+      - "/scalardb.properties"
+      - "--coordinator"
+      - "--replication-factor"
       - "1"
     networks:
       - scalar-network
     restart: on-failure
 
   scalar-ledger-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.2.0
+    image: ghcr.io/scalar-labs/scalar-client:3.3.0
     container_name: "scalardl-samples-scalar-ledger-as-client-1"
     volumes:
       - ./fixture/ledger.pem:/scalar/ledger.pem
@@ -39,7 +41,7 @@ services:
     restart: on-failure:5
 
   scalar-audior-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.2.0
+    image: ghcr.io/scalar-labs/scalar-client:3.3.0
     container_name: "scalardl-samples-scalar-auditor-as-client-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem
@@ -67,7 +69,7 @@ services:
       - SCALAR_DL_LEDGER_AUDITOR_ENABLED=true
 
   scalar-auditor:
-    image: ghcr.io/scalar-labs/scalar-auditor:3.2.0
+    image: ghcr.io/scalar-labs/scalar-auditor:3.3.0
     container_name: "scalardl-samples-scalar-auditor-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,19 +18,21 @@ services:
       - scalar-network
 
   scalardl-ledger-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.2.0
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.3.0
+    volumes:
+      - ./scalardb.properties:/scalardb.properties
     command:
-      - "--cassandra"
-      - "-h"
-      - "cassandra"
-      - "-R"
+      - "-c"
+      - "/scalardb.properties"
+      - "--coordinator"
+      - "--replication-factor"
       - "1"
     networks:
       - scalar-network
     restart: on-failure
 
   scalar-ledger:
-    image: ghcr.io/scalar-labs/scalar-ledger:3.2.0
+    image: ghcr.io/scalar-labs/scalar-ledger:3.3.0
     container_name: "scalardl-samples-scalar-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem

--- a/scalardb.properties
+++ b/scalardb.properties
@@ -1,0 +1,2 @@
+scalar.db.storage=cassandra
+scalar.db.contact_points=cassandra


### PR DESCRIPTION
This PR upgrades Scalar DL to 3.3.0.
It also revises the command in Docker Compose file to conform to the new Scalar DB schema loader.