### PR TITLE
Ignore IDE and Gradle-related files from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.classpath
+.project
+.settings/
+.idea/
+*.iml
+*.iws
+bin/
+build/
+.gradle/


### PR DESCRIPTION
This PR creates a `.gitignore` file to ignore some IDE and Gradle-related files.