### PR TITLE
Upgrade Scalar DL Samples with Scalar DL 3.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.3.2'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.4.0'
 }
 
 sourceCompatibility = 1.8

--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   scalardl-auditor-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.3.0
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.4.0
     environment:
       - SCHEMA_TYPE=auditor
     volumes:
@@ -17,7 +17,7 @@ services:
     restart: on-failure
 
   scalar-ledger-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.3.2
+    image: ghcr.io/scalar-labs/scalar-client:3.4.0
     container_name: "scalardl-samples-scalar-ledger-as-client-1"
     volumes:
       - ./fixture/ledger.pem:/scalar/ledger.pem
@@ -41,7 +41,7 @@ services:
     restart: on-failure:5
 
   scalar-audior-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.3.2
+    image: ghcr.io/scalar-labs/scalar-client:3.4.0
     container_name: "scalardl-samples-scalar-auditor-as-client-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem
@@ -69,7 +69,7 @@ services:
       - SCALAR_DL_LEDGER_AUDITOR_ENABLED=true
 
   scalar-auditor:
-    image: ghcr.io/scalar-labs/scalar-auditor:3.3.2
+    image: ghcr.io/scalar-labs/scalar-auditor:3.4.0
     container_name: "scalardl-samples-scalar-auditor-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - scalar-network
 
   scalardl-ledger-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.3.0
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.4.0
     volumes:
       - ./scalardb.properties:/scalardb.properties
     command:
@@ -32,7 +32,7 @@ services:
     restart: on-failure
 
   scalar-ledger:
-    image: ghcr.io/scalar-labs/scalar-ledger:3.3.2
+    image: ghcr.io/scalar-labs/scalar-ledger:3.4.0
     container_name: "scalardl-samples-scalar-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem


### PR DESCRIPTION
This PR upgrade the master branch to use Scalar DL 3.4.0.