### PR TITLE
Upgrade Scalar DL to 3.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.5.2'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.5.3'
 }
 
 sourceCompatibility = 1.8

--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -17,7 +17,7 @@ services:
     restart: on-failure
 
   scalar-ledger-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.5.2
+    image: ghcr.io/scalar-labs/scalar-client:3.5.3
     container_name: "scalardl-samples-scalar-ledger-as-client-1"
     volumes:
       - ./fixture/ledger.pem:/scalar/ledger.pem
@@ -41,7 +41,7 @@ services:
     restart: on-failure:5
 
   scalar-audior-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.5.2
+    image: ghcr.io/scalar-labs/scalar-client:3.5.3
     container_name: "scalardl-samples-scalar-auditor-as-client-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem
@@ -69,7 +69,7 @@ services:
       - SCALAR_DL_LEDGER_AUDITOR_ENABLED=true
 
   scalar-auditor:
-    image: ghcr.io/scalar-labs/scalar-auditor:3.5.2
+    image: ghcr.io/scalar-labs/scalar-auditor:3.5.3
     container_name: "scalardl-samples-scalar-auditor-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     restart: on-failure
 
   scalar-ledger:
-    image: ghcr.io/scalar-labs/scalar-ledger:3.5.2
+    image: ghcr.io/scalar-labs/scalar-ledger:3.5.3
     container_name: "scalardl-samples-scalar-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem


### PR DESCRIPTION
This PR upgrades Scalar DL to version 3.5.3.

When this PR is merged. It should be picked into the 3.5 branch too.