### PR TITLE
Move README.md to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,1 @@
-# Scalar DL Samples
-
-* Clone this repository
-```
-$ git clone https://github.com/scalar-labs/scalardl-samples.git
-```
-
-- Install Scalar DL
-  - [How to install Scalar DL in your local environment with Docker](https://github.com/scalar-labs/scalardl/blob/master/docs/installation-with-docker.md)
-
-- Play around with a sample
-  - [Getting Started with Scalar DL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md)
+docs/README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Scalar DL Samples
+
+* Clone this repository
+```
+$ git clone https://github.com/scalar-labs/scalardl-samples.git
+```
+
+- Install Scalar DL
+  - [How to install Scalar DL in your local environment with Docker](https://github.com/scalar-labs/scalardl/blob/master/docs/installation-with-docker.md)
+
+- Play around with a sample
+  - [Getting Started with Scalar DL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md)


### PR DESCRIPTION
This PR moves README.md to the docs folder and create a soft link in the root folder.