### PR TITLE
Control the container starting order

### DIFF
--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -6,6 +6,9 @@ services:
       - SCHEMA_TYPE=auditor
     volumes:
       - ./scalardb.properties:/scalardb.properties
+    depends_on:
+      cassandra:
+        condition: service_healthy
     command:
       - "-c"
       - "/scalardb.properties"
@@ -23,8 +26,10 @@ services:
       - ./fixture/ledger.pem:/scalar/ledger.pem
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
     depends_on:
-      - ledger-envoy
-      - auditor-envoy
+      scalar-ledger:
+        condition: service_healthy
+      scalar-auditor:
+        condition: service_healthy
     environment:
       - SCALAR_DL_CLIENT_SERVER_HOST=ledger-envoy
       - SCALAR_DL_CLIENT_AUDITOR_HOST=auditor-envoy
@@ -47,8 +52,10 @@ services:
       - ./fixture/auditor.pem:/scalar/auditor.pem
       - ./fixture/auditor-key.pem:/scalar/auditor-key.pem
     depends_on:
-      - ledger-envoy
-      - auditor-envoy
+      scalar-ledger:
+        condition: service_healthy
+      scalar-auditor:
+        condition: service_healthy
     environment:
       - SCALAR_DL_CLIENT_SERVER_HOST=ledger-envoy
       - SCALAR_DL_CLIENT_AUDITOR_HOST=auditor-envoy
@@ -75,7 +82,8 @@ services:
       - ./fixture/auditor.pem:/scalar/auditor.pem
       - ./fixture/auditor-key.pem:/scalar/auditor-key.pem
     depends_on:
-      - cassandra
+      scalardl-auditor-schema-loader-cassandra:
+        condition: service_completed_successfully
     environment:
       - SCALAR_DB_CONTACT_POINTS=cassandra
       - SCALAR_DB_STORAGE=cassandra
@@ -84,12 +92,12 @@ services:
       - SCALAR_DL_AUDITOR_PRIVATE_KEY_PATH=/scalar/auditor-key.pem
     networks:
       - scalar-network
-    # Overriding the CMD instruction in the scalar-ledger Dockerfile to add the -wait option.
-    command: |
-      dockerize -template auditor.properties.tmpl:auditor.properties
-      -template log4j2.properties.tmpl:log4j2.properties
-      -wait tcp://cassandra:9042 -timeout 60s
-      ./bin/scalar-auditor --config auditor.properties
+    healthcheck:
+      test: ["CMD-SHELL", "grpc_health_probe -addr=localhost:40051 && grpc_health_probe -addr=auditor-envoy:40051 || exit 1"]
+      interval: 1s
+      timeout: 10s
+      retries: 60
+      start_period: 10s
 
   auditor-envoy:
     image: ghcr.io/scalar-labs/scalar-envoy:1.3.0
@@ -99,7 +107,8 @@ services:
       - "40051:40051"
       - "40052:40052"
     depends_on:
-      - scalar-auditor
+      scalar-auditor:
+        condition: service_started
     environment:
       - admin_access_log_path=/dev/stdout
       - scalardl_address=scalar-auditor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,20 @@ services:
       - CASSANDRA_ENDPOINT_SNITCH=GossipingPropertyFileSnitch
     networks:
       - scalar-network
+    healthcheck:
+      test: ["CMD-SHELL", "cqlsh < /dev/null || exit 1"]
+      interval: 1s
+      timeout: 10s
+      retries: 60
+      start_period: 30s
 
   scalardl-ledger-schema-loader-cassandra:
     image: ghcr.io/scalar-labs/scalardl-schema-loader:3.7.0
     volumes:
       - ./scalardb.properties:/scalardb.properties
+    depends_on:
+      cassandra:
+        condition: service_healthy
     command:
       - "-c"
       - "/scalardb.properties"
@@ -37,7 +46,8 @@ services:
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
     depends_on:
-      - cassandra
+      scalardl-ledger-schema-loader-cassandra:
+        condition: service_completed_successfully
     environment:
       - SCALAR_DB_CONTACT_POINTS=cassandra
       - SCALAR_DB_STORAGE=cassandra
@@ -45,12 +55,12 @@ services:
       - SCALAR_DL_LEDGER_PROOF_PRIVATE_KEY_PATH=/scalar/ledger-key.pem
     networks:
       - scalar-network
-    # Overriding the CMD instruction in the scalar-ledger Dockerfile to add the -wait option.
-    command: |
-      dockerize -template ledger.properties.tmpl:ledger.properties
-      -template log4j2.properties.tmpl:log4j2.properties
-      -wait tcp://cassandra:9042 -timeout 60s
-      ./bin/scalar-ledger --config ledger.properties
+    healthcheck:
+      test: ["CMD-SHELL", "grpc_health_probe -addr=localhost:50051 && grpc_health_probe -addr=ledger-envoy:50051 || exit 1"]
+      interval: 1s
+      timeout: 10s
+      retries: 60
+      start_period: 10s
 
   ledger-envoy:
     image: ghcr.io/scalar-labs/scalar-envoy:1.3.0
@@ -60,7 +70,8 @@ services:
       - "50051:50051"
       - "50052:50052"
     depends_on:
-      - scalar-ledger
+      scalar-ledger:
+        condition: service_started
     environment:
       - admin_access_log_path=/dev/stdout
       - scalardl_address=scalar-ledger


### PR DESCRIPTION
This PR updates the `docker-compose.yaml` files to control the containers' starting order.

The overview of the starting order is the following.

* Overview
  ```
  [Cassandra]
    ->(Wait until Cassandra accepts client requests)
      ->[ScalarDL Schema Loader (Ledger)]
      ->[ScalarDL Schema Loader (Auditor)]
        ->(Wait until Schema Loader completes)
          ->[ScalarDL Ledger]
          ->[ScalarDL Auditor]
            ->(Wait until Ledger/Auditor containers start)
              ->[Envoy for Ledger]
              ->[Envoy for Auditor]
                ->(Wait until ScalarDL and Envoy are healthy by health check)
                  ->[Ledger as client (register Ledger's cert file)]
                  ->[Auditor as client (register Auditor's cert file)]
  ```
  Note: `[]` means containers and `()` means conditions.

Now we are using the `-wait` flag of the `dockerize` command to control the service starting order. However, we will remove the `dockerize` command from each container image since ScalarDL v4.

In this PR, we can remove this dependency on the `-wait` flag of the `dockerize` command by using the docker compose native health check feature. (We can apply this update to ScalarDL v3.x)

The client containers use the `dockerize` to create `client.properties` yet, but we can remove this `dockerize` command after the following PR will be merged. This is because, we will not need to create `client.properties` by the `dockerize` command after this PR will be merged. (We need additional updates after the following PR will be merged to support `4.0.0-SNAPSHOT`.)
https://github.com/scalar-labs/scalar/pull/942

Please take a look!