### PR TITLE
Use the latest release version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.8.0'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.9.0'
 }
 
 sourceCompatibility = 1.8

--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   scalardl-auditor-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:4.0.0-SNAPSHOT
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.0
     environment:
       - SCHEMA_TYPE=auditor
     volumes:
@@ -20,7 +20,7 @@ services:
     restart: on-failure
 
   scalar-ledger-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:4.0.0-SNAPSHOT
+    image: ghcr.io/scalar-labs/scalar-client:3.9.0
     container_name: "scalardl-samples-scalar-ledger-as-client-1"
     volumes:
       - ./fixture/ledger.pem:/scalar/ledger.pem
@@ -44,7 +44,7 @@ services:
     restart: on-failure:5
 
   scalar-audior-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:4.0.0-SNAPSHOT
+    image: ghcr.io/scalar-labs/scalar-client:3.9.0
     container_name: "scalardl-samples-scalar-auditor-as-client-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem
@@ -72,8 +72,8 @@ services:
       - SCALAR_DL_LEDGER_AUDITOR_ENABLED=true
 
   scalar-auditor:
-    image: ghcr.io/scalar-labs/scalar-auditor:4.0.0-SNAPSHOT
-    # image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor:4.0.0-SNAPSHOT
+    image: ghcr.io/scalar-labs/scalar-auditor:3.9.0
+    # image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor:3.9.0
     container_name: "scalardl-samples-scalar-auditor-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem
@@ -97,7 +97,7 @@ services:
       start_period: 10s
 
   auditor-envoy:
-    image: ghcr.io/scalar-labs/scalar-envoy:2.0.0-SNAPSHOT
+    image: ghcr.io/scalar-labs/scalar-envoy:1.5.0
     container_name: "scalardl-samples-auditor-envoy-1"
     ports:
       - "9902:9901"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       start_period: 30s
 
   scalardl-ledger-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:4.0.0-SNAPSHOT
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.0
     volumes:
       - ./scalardb.properties:/scalardb.properties
     depends_on:
@@ -41,8 +41,8 @@ services:
     restart: on-failure
 
   scalar-ledger:
-    image: ghcr.io/scalar-labs/scalar-ledger:4.0.0-SNAPSHOT
-    # image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger:4.0.0-SNAPSHOT
+    image: ghcr.io/scalar-labs/scalar-ledger:3.9.0
+    # image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger:3.9.0
     container_name: "scalardl-samples-scalar-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
@@ -64,7 +64,7 @@ services:
       start_period: 10s
 
   ledger-envoy:
-    image: ghcr.io/scalar-labs/scalar-envoy:2.0.0-SNAPSHOT
+    image: ghcr.io/scalar-labs/scalar-envoy:1.5.0
     container_name: "scalardl-samples-ledger-envoy-1"
     ports:
       - "9901:9901"


### PR DESCRIPTION
This PR changes the default version from the snapshot one to the latest release one.

Although we are going to ask users to use the specific version by checking it out in the guide (scalar-labs/docs-internal-scalardl#62), users might accidentally use the default branch version, i.e., the snapshot one. It's not preferable for users to use (sometimes-)unstable versions unintentionally. That's why I'm writing this PR.

The other option is to set the default branch to the latest release branch to avoid the accident and keep using the snapshot version on the master. Please let me know your opinion if this approach is better than changing the version.