### PR TITLE
Fix client entrypoint command in v3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.9.0'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.9.1'
 }
 
 sourceCompatibility = 1.8

--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -40,6 +40,8 @@ services:
     networks:
       - scalar-network
     command: |
+      dockerize -template client.properties.tmpl:client.properties
+      -template log4j2.properties.tmpl:log4j2.properties
       ./client/bin/register-cert --config client.properties
     restart: on-failure:5
 
@@ -64,6 +66,8 @@ services:
     networks:
       - scalar-network
     command: |
+      dockerize -template client.properties.tmpl:client.properties
+      -template log4j2.properties.tmpl:log4j2.properties
       ./client/bin/register-cert --config client.properties
     restart: on-failure:5
 

--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   scalardl-auditor-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.0
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.1
     environment:
       - SCHEMA_TYPE=auditor
     volumes:
@@ -20,7 +20,7 @@ services:
     restart: on-failure
 
   scalar-ledger-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.9.0
+    image: ghcr.io/scalar-labs/scalar-client:3.9.1
     container_name: "scalardl-samples-scalar-ledger-as-client-1"
     volumes:
       - ./fixture/ledger.pem:/scalar/ledger.pem
@@ -44,7 +44,7 @@ services:
     restart: on-failure:5
 
   scalar-audior-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.9.0
+    image: ghcr.io/scalar-labs/scalar-client:3.9.1
     container_name: "scalardl-samples-scalar-auditor-as-client-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem
@@ -72,8 +72,8 @@ services:
       - SCALAR_DL_LEDGER_AUDITOR_ENABLED=true
 
   scalar-auditor:
-    image: ghcr.io/scalar-labs/scalar-auditor:3.9.0
-    # image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor:3.9.0
+    image: ghcr.io/scalar-labs/scalar-auditor:3.9.1
+    # image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor:3.9.1
     container_name: "scalardl-samples-scalar-auditor-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       start_period: 30s
 
   scalardl-ledger-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.0
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.1
     volumes:
       - ./scalardb.properties:/scalardb.properties
     depends_on:
@@ -41,8 +41,8 @@ services:
     restart: on-failure
 
   scalar-ledger:
-    image: ghcr.io/scalar-labs/scalar-ledger:3.9.0
-    # image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger:3.9.0
+    image: ghcr.io/scalar-labs/scalar-ledger:3.9.1
+    # image: 709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger:3.9.1
     container_name: "scalardl-samples-scalar-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem


### PR DESCRIPTION
## Description

This PR fixes an entrypoint command for containers that register certificates for ScalarDL ledger and auditor in the sample application. The client container image of ScalarDL v3.9 executes `dockerize -template` internally to generate client.properties file. However, the `command` field in the docker compose file does not contain that and the two containers based on the image exit with `FileNotFoundException : client.properties`. This issue is not observed in versions prior to v3.8 and the latest version does not require the dockerize command. 

## Related issues and/or PRs

N/A

## Changes made

Add `dockerize -template` command in `command` field in the following file.

- docker-compose-auditor.yml

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A