### PR TITLE
Change relative docs links to docs site links in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ $ git clone https://github.com/scalar-labs/scalardl-samples.git
 ```
 
 - Install ScalarDL
-  - [How to install ScalarDL in your local environment with Docker](https://github.com/scalar-labs/scalardl/blob/master/docs/installation-with-docker.md)
+  - [How to install ScalarDL in your local environment with Docker](https://scalardl.scalar-labs.com/docs/latest/installation-with-docker/)
 
 - Play around with a sample
-  - [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md)
+  - [Getting Started with ScalarDL](https://scalardl.scalar-labs.com/docs/latest/getting-started/)


### PR DESCRIPTION
## Description

This PR updates links to the docs listed in the README to point to the docs site instead of GitHub.

## Related issues and/or PRs

N/A

## Changes made

- Changed relative links to the docs on GitHub to links to the docs site.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
