### PR TITLE
Upgrade ScalarDL to 3.9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.9.2'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.9.3'
 }
 
 sourceCompatibility = 1.8

--- a/docker-compose-auditor.yml
+++ b/docker-compose-auditor.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   scalardl-auditor-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.2
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.3
     environment:
       - SCHEMA_TYPE=auditor
     volumes:
@@ -20,7 +20,7 @@ services:
     restart: on-failure
 
   scalar-ledger-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.9.2
+    image: ghcr.io/scalar-labs/scalar-client:3.9.3
     container_name: "scalardl-samples-scalar-ledger-as-client-1"
     volumes:
       - ./fixture/ledger.pem:/scalar/ledger.pem
@@ -46,7 +46,7 @@ services:
     restart: on-failure:5
 
   scalar-audior-as-client:
-    image: ghcr.io/scalar-labs/scalar-client:3.9.2
+    image: ghcr.io/scalar-labs/scalar-client:3.9.3
     container_name: "scalardl-samples-scalar-auditor-as-client-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem
@@ -76,7 +76,7 @@ services:
       - SCALAR_DL_LEDGER_AUDITOR_ENABLED=true
 
   scalar-auditor:
-    image: ghcr.io/scalar-labs/scalardl-auditor-byol:3.9.2
+    image: ghcr.io/scalar-labs/scalardl-auditor-byol:3.9.3
     container_name: "scalardl-samples-scalar-auditor-1"
     volumes:
       - ./fixture/auditor.pem:/scalar/auditor.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       start_period: 30s
 
   scalardl-ledger-schema-loader-cassandra:
-    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.2
+    image: ghcr.io/scalar-labs/scalardl-schema-loader:3.9.3
     volumes:
       - ./scalardb.properties:/scalardb.properties
     depends_on:
@@ -41,7 +41,7 @@ services:
     restart: on-failure
 
   scalar-ledger:
-    image: ghcr.io/scalar-labs/scalardl-ledger-byol:3.9.2
+    image: ghcr.io/scalar-labs/scalardl-ledger-byol:3.9.3
     container_name: "scalardl-samples-scalar-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem


### PR DESCRIPTION
This PR upgrades the ScalarDL version to 3.9.3. Once it's merged, I will do a similar thing to the 3.8 and 3.9 branches and create tags. Please take a quick look!