### PR TITLE
Use Community edition for ScalarDL Ledger

### DIFF
--- a/docker-compose-ledger-cassandra.yml
+++ b/docker-compose-ledger-cassandra.yml
@@ -32,9 +32,10 @@ services:
       - scalar-network
     restart: on-failure
 
-  scalar-ledger:
-    image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
-    container_name: "scalardl-samples-scalar-ledger-1"
+  scalardl-ledger:
+    image: ghcr.io/scalar-labs/scalardl-ledger:${SCALARDL_VERSION}
+    # image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
+    container_name: "scalardl-samples-scalardl-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
       - ./fixture/ledger.properties.tmpl:/scalar/ledger/ledger.properties.tmpl

--- a/docker-compose-ledger-common.yml
+++ b/docker-compose-ledger-common.yml
@@ -7,11 +7,11 @@ services:
       - "50051:50051"
       - "50052:50052"
     depends_on:
-      scalar-ledger:
+      scalardl-ledger:
         condition: service_started
     environment:
       - admin_access_log_path=/dev/stdout
-      - scalardl_address=scalar-ledger
+      - scalardl_address=scalardl-ledger
       - service_listeners=scalar-service:50051,scalar-privileged:50052
       - envoy_tls=false
     networks:

--- a/docker-compose-ledger-cosmosdb.yml
+++ b/docker-compose-ledger-cosmosdb.yml
@@ -14,9 +14,10 @@ services:
       - scalar-network
     restart: on-failure
 
-  scalar-ledger:
-    image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
-    container_name: "scalardl-samples-scalar-ledger-1"
+  scalardl-ledger:
+    image: ghcr.io/scalar-labs/scalardl-ledger:${SCALARDL_VERSION}
+    # image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
+    container_name: "scalardl-samples-scalardl-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
       - ./fixture/ledger.properties.tmpl:/scalar/ledger/ledger.properties.tmpl

--- a/docker-compose-ledger-dynamodb.yml
+++ b/docker-compose-ledger-dynamodb.yml
@@ -33,9 +33,10 @@ services:
       - scalar-network
     restart: on-failure
 
-  scalar-ledger:
-    image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
-    container_name: "scalardl-samples-scalar-ledger-1"
+  scalardl-ledger:
+    image: ghcr.io/scalar-labs/scalardl-ledger:${SCALARDL_VERSION}
+    # image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
+    container_name: "scalardl-samples-scalardl-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
       - ./fixture/ledger.properties.tmpl:/scalar/ledger/ledger.properties.tmpl

--- a/docker-compose-ledger-mysql.yml
+++ b/docker-compose-ledger-mysql.yml
@@ -33,9 +33,10 @@ services:
       - scalar-network
     restart: on-failure
 
-  scalar-ledger:
-    image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
-    container_name: "scalardl-samples-scalar-ledger-1"
+  scalardl-ledger:
+    image: ghcr.io/scalar-labs/scalardl-ledger:${SCALARDL_VERSION}
+    # image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
+    container_name: "scalardl-samples-scalardl-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
       - ./fixture/ledger.properties.tmpl:/scalar/ledger/ledger.properties.tmpl

--- a/docker-compose-ledger-oracle.yml
+++ b/docker-compose-ledger-oracle.yml
@@ -33,9 +33,10 @@ services:
       - scalar-network
     restart: on-failure
 
-  scalar-ledger:
-    image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
-    container_name: "scalardl-samples-scalar-ledger-1"
+  scalardl-ledger:
+    image: ghcr.io/scalar-labs/scalardl-ledger:${SCALARDL_VERSION}
+    # image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
+    container_name: "scalardl-samples-scalardl-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
       - ./fixture/ledger.properties.tmpl:/scalar/ledger/ledger.properties.tmpl

--- a/docker-compose-ledger-postgres.yml
+++ b/docker-compose-ledger-postgres.yml
@@ -34,9 +34,10 @@ services:
       - scalar-network
     restart: on-failure
 
-  scalar-ledger:
-    image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
-    container_name: "scalardl-samples-scalar-ledger-1"
+  scalardl-ledger:
+    image: ghcr.io/scalar-labs/scalardl-ledger:${SCALARDL_VERSION}
+    # image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
+    container_name: "scalardl-samples-scalardl-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
       - ./fixture/ledger.properties.tmpl:/scalar/ledger/ledger.properties.tmpl

--- a/docker-compose-ledger-sqlserver.yml
+++ b/docker-compose-ledger-sqlserver.yml
@@ -35,9 +35,10 @@ services:
       - scalar-network
     restart: on-failure
 
-  scalar-ledger:
-    image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
-    container_name: "scalardl-samples-scalar-ledger-1"
+  scalardl-ledger:
+    image: ghcr.io/scalar-labs/scalardl-ledger:${SCALARDL_VERSION}
+    # image: ghcr.io/scalar-labs/scalardl-ledger-byol:${SCALARDL_VERSION}
+    container_name: "scalardl-samples-scalardl-ledger-1"
     volumes:
       - ./fixture/ledger-key.pem:/scalar/ledger-key.pem
       - ./fixture/ledger.properties.tmpl:/scalar/ledger/ledger.properties.tmpl


### PR DESCRIPTION
## Description

This PR changes the default ScalarDL Ledger image to the Community edition so that all users can easily try to run ScalarDL without configuring a license. You can check the behavior based on the docs in this PR https://github.com/scalar-labs/docs-internal-scalardl/pull/368.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-internal-scalardl/pull/368

## Changes made

- Change the default docker image for ScalarDL to the Community edition

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
