### PR TITLE
Fix to disable Auditor by default for PostgreSQL

### DIFF
--- a/postgres/ledger.properties
+++ b/postgres/ledger.properties
@@ -6,7 +6,7 @@ scalar.db.contact_points=jdbc:postgresql://postgres/
 scalar.db.username=postgres
 scalar.db.password=postgres
 
-scalar.dl.ledger.auditor.enabled=true
+# scalar.dl.ledger.auditor.enabled=true
 
 ##### PLEASE REPLACE THIS VALUE WITH YOUR LICENSE KEY (ENTERPRISE EDITION ONLY) #####
 scalar.dl.licensing.license_key=<SET_YOUR_LICENSE_KEY>


### PR DESCRIPTION
## Description

This PR disables the Auditor by default for the PostgreSQL-based configuration. Sorry, I missed it in the last PR #80.

## Related issues and/or PRs

- #80
