### PR TITLE
Remove unused auditor cert config

### DIFF
--- a/cassandra/auditor.properties
+++ b/cassandra/auditor.properties
@@ -1,5 +1,4 @@
 scalar.dl.auditor.ledger.host=ledger-envoy
-scalar.dl.auditor.cert_path=/scalar/auditor.pem
 scalar.dl.auditor.private_key_path=/scalar/auditor-key.pem
 scalar.dl.licensing.license_check_cert_path=/scalar/license-cert.pem
 scalar.db.storage=cassandra

--- a/cosmosdb/auditor.properties
+++ b/cosmosdb/auditor.properties
@@ -1,5 +1,4 @@
 scalar.dl.auditor.ledger.host=ledger-envoy
-scalar.dl.auditor.cert_path=/scalar/auditor.pem
 scalar.dl.auditor.private_key_path=/scalar/auditor-key.pem
 scalar.dl.licensing.license_check_cert_path=/scalar/license-cert.pem
 scalar.db.storage=cosmos

--- a/dynamodb/auditor.properties
+++ b/dynamodb/auditor.properties
@@ -1,5 +1,4 @@
 scalar.dl.auditor.ledger.host=ledger-envoy
-scalar.dl.auditor.cert_path=/scalar/auditor.pem
 scalar.dl.auditor.private_key_path=/scalar/auditor-key.pem
 scalar.dl.licensing.license_check_cert_path=/scalar/license-cert.pem
 scalar.db.storage=dynamo

--- a/mysql/auditor.properties
+++ b/mysql/auditor.properties
@@ -1,5 +1,4 @@
 scalar.dl.auditor.ledger.host=ledger-envoy
-scalar.dl.auditor.cert_path=/scalar/auditor.pem
 scalar.dl.auditor.private_key_path=/scalar/auditor-key.pem
 scalar.dl.licensing.license_check_cert_path=/scalar/license-cert.pem
 scalar.db.storage=jdbc

--- a/oracle/auditor.properties
+++ b/oracle/auditor.properties
@@ -1,5 +1,4 @@
 scalar.dl.auditor.ledger.host=ledger-envoy
-scalar.dl.auditor.cert_path=/scalar/auditor.pem
 scalar.dl.auditor.private_key_path=/scalar/auditor-key.pem
 scalar.dl.licensing.license_check_cert_path=/scalar/license-cert.pem
 scalar.db.storage=jdbc

--- a/postgres/auditor.properties
+++ b/postgres/auditor.properties
@@ -1,5 +1,4 @@
 scalar.dl.auditor.ledger.host=ledger-envoy
-scalar.dl.auditor.cert_path=/scalar/auditor.pem
 scalar.dl.auditor.private_key_path=/scalar/auditor-key.pem
 scalar.dl.licensing.license_check_cert_path=/scalar/license-cert.pem
 scalar.db.storage=jdbc

--- a/sqlserver/auditor.properties
+++ b/sqlserver/auditor.properties
@@ -1,5 +1,4 @@
 scalar.dl.auditor.ledger.host=ledger-envoy
-scalar.dl.auditor.cert_path=/scalar/auditor.pem
 scalar.dl.auditor.private_key_path=/scalar/auditor-key.pem
 scalar.dl.licensing.license_check_cert_path=/scalar/license-cert.pem
 scalar.db.storage=jdbc


### PR DESCRIPTION
This PR removes unused cert parameters in the configuration sample and template to avoid confusion. The Ledger/Auditor certificates are registered using their properties as "clients", so they don't have to be loaded as servers.
